### PR TITLE
Added Asciidoc3 and HTML-escape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.pyc
 MANIFEST
 dist
+.bzr
+.bzrignore
+.idea
+_*
+env/
+dycco.egg-info/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+v1.0.2  2022-03-17 -- New AST and Python 3 only operation
+
 v1.0.1, 2014-05-03 -- Python 3 compatibility.
 
 v1.0.0, 2014-05-02 -- Initial release.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v1.0.2  2022-03-17 -- New AST and Python 3 only operation
+v1.0.2  2022-03-17 -- New AST and Python 3 only operation. Added asciidoc3 option
 
 v1.0.1, 2014-05-03 -- Python 3 compatibility.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2011-2014 by Will McCutchen and individual contributors.
+Copyright (C) 2011-2022 by Will McCutchen and individual contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ Outputs::
       -h, --help            show this help message and exit
       -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                             Output directory (will be created if necessary)
+      -a, --asciidoc3       Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)
+
 
 Library Usage
 -------------

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Credits
 Dycco is just a simple re-implementation of `Docco`_, with some inspiration and
 template code from its primary Python port `Pycco`_.
 
-.. _Docco: http://jashkenas.github.com/docco/
-.. _Pycco: http://fitzgen.github.com/pycco/
+.. _Docco: https://ashkenas.com/docco/
+.. _Pycco: https://github.com/pycco-docs/pycco
 .. _pip: http://www.pip-installer.org/
 .. _its self-generated docs: https://mccutchen.github.io/dycco/

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ This port of Docco has fewer features than the pimary Python port, `Pycco`_.
 For instance, Dycco can generate documentation for Python files and nothing
 else. It was written mostly as a reason to play with Python's AST.
 
-You should probably use `Pycco`_ instead.
+You can use `Pycco`_ instead.
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ Outputs::
       -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                             Output directory (will be created if necessary)
       -a, --asciidoc3       Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)
+      -e, --escape-html     Run the documentation through html.escape() before markdown or asciidoc3
+
 
 
 Library Usage

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -5,9 +5,9 @@ import sys
 from .dycco import document
 
 
-def main(paths, output_dir, use_ascii:bool):
+def main(paths, output_dir, use_ascii:bool, escape_html:bool):
     try:
-        document(paths, output_dir, use_ascii)
+        document(paths, output_dir, use_ascii, escape_html)
     except IOError as e:
         logging.error('Unable to open file: %s', e)
         return 1
@@ -24,6 +24,8 @@ if __name__ == '__main__':
     arg_parser.add_argument('-o', '--output-dir', default='docs', help='Output directory (will be created if necessary)')
     arg_parser.add_argument('-a', '--asciidoc3', action='store_true', default=False, dest='use_ascii',
         help='Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)')
+    arg_parser.add_argument('-e', '--escape-html', action='store_true', default=False, dest='escape_html',
+        help='Run the documentation through html.escape() before markdown or asciidoc3')
 
     args = arg_parser.parse_args()
-    sys.exit(main(args.source_file, args.output_dir, args.use_ascii))
+    sys.exit(main(args.source_file, args.output_dir, args.use_ascii, args.escape_html))

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -19,15 +19,9 @@ def main(paths, output_dir):
 
 
 if __name__ == '__main__':
-    arg_parser = argparse.ArgumentParser(
-        prog='dycco',
-        description='Literate-style documentation generator.')
-    arg_parser.add_argument(
-        'source_file', nargs='+', default=sys.stdin,
-        help='Source files to document')
-    arg_parser.add_argument(
-        '-o', '--output-dir', default='docs',
-        help='Output directory (will be created if necessary)')
+    arg_parser = argparse.ArgumentParser(prog='dycco', description='Literate-style documentation generator.')
+    arg_parser.add_argument('source_file', nargs='+', default=sys.stdin, help='Source files to document')
+    arg_parser.add_argument('-o', '--output-dir', default='docs', help='Output directory (will be created if necessary)')
 
     args = arg_parser.parse_args()
     sys.exit(main(args.source_file, args.output_dir))

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -5,9 +5,9 @@ import sys
 from .dycco import document
 
 
-def main(paths, output_dir):
+def main(paths, output_dir, use_ascii:bool):
     try:
-        document(paths, output_dir)
+        document(paths, output_dir, use_ascii)
     except IOError as e:
         logging.error('Unable to open file: %s', e)
         return 1
@@ -22,6 +22,8 @@ if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser(prog='dycco', description='Literate-style documentation generator.')
     arg_parser.add_argument('source_file', nargs='+', default=sys.stdin, help='Source files to document')
     arg_parser.add_argument('-o', '--output-dir', default='docs', help='Output directory (will be created if necessary)')
+    arg_parser.add_argument('-a', '--asciidoc3', action='store_true', default=False, dest='use_ascii',
+        help='Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)')
 
     args = arg_parser.parse_args()
-    sys.exit(main(args.source_file, args.output_dir))
+    sys.exit(main(args.source_file, args.output_dir, args.use_ascii))

--- a/dycco/dycco.py
+++ b/dycco/dycco.py
@@ -56,8 +56,8 @@ DYCCO_CSS = os.path.join(DYCCO_RESOURCES, 'dycco.css')
 # We need a positive integer type
 
 
-# For Python 2 & 3 compatibility, although this code is unlikely
-# to work correctly for Python 2 any more
+# For Python 2 & 3 compatibility (although this code is unlikely
+# to work correctly for Python 2 any more).
 try:
     string_type = basestring
 except NameError:

--- a/dycco/tests/input/bad_shebang_and_coding.py
+++ b/dycco/tests/input/bad_shebang_and_coding.py
@@ -1,4 +1,5 @@
 # Shebang must come first
 #!/usr/bin/env/python2.6
+
 # -*- coding: utf8 -*-
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_coding.py
+++ b/dycco/tests/input/skip_coding.py
@@ -1,2 +1,2 @@
 # coding=utf8
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_emacs_coding.py
+++ b/dycco/tests/input/skip_emacs_coding.py
@@ -1,2 +1,2 @@
 # -*- coding: utf8 -*-
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_shebang.py
+++ b/dycco/tests/input/skip_shebang.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python2.6
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_shebang_and_coding.py
+++ b/dycco/tests/input/skip_shebang_and_coding.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env/python2.6
 # -*- coding: utf8 -*-
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/torturetest.py
+++ b/dycco/tests/input/torturetest.py
@@ -88,4 +88,4 @@ def decorated_function_definition(function, which, takes, many, args, whose,
     """A *decorated* long function definition With some very important
     documentation.
     """
-    print 'Hello!'
+    print('Hello!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Markdown==2.4
-Pygments==2.7.4
-pystache==0.5.3
+Markdown>=2.4
+Pygments>=2.7.4
+pystache>=0.5.3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name='dycco',
-    version='1.0.1',
+    version='1.0.2',
     description='Literate-programming-style documentation generator.',
     long_description=read('README.rst'),
     url='https://github.com/mccutchen/dycco',
@@ -23,7 +23,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',


### PR DESCRIPTION
Added -e / --escape-html option to run documentation through Python's html.escape() before processing with Markdown or Asciidoc3 (otherwise things like <title> in a comment disrupt the output when displayed). Updated documentation accordingly.