### PR TITLE
-a, -e and -f options now complete.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.pyc
 MANIFEST
 dist
+.bzr
+.bzrignore
+.idea
+_*
+env/
+dycco.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 _*
 env/
 dycco.egg-info/
+build/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+v1.0.2  2022-03-17 -- New AST and Python 3 only operation
+
 v1.0.1, 2014-05-03 -- Python 3 compatibility.
 
 v1.0.0, 2014-05-02 -- Initial release.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v1.0.2  2022-03-17 -- New AST and Python 3 only operation
+v1.0.2  2022-03-17 -- New AST and Python 3 only operation. Added asciidoc3 option
 
 v1.0.1, 2014-05-03 -- Python 3 compatibility.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2011-2014 by Will McCutchen and individual contributors.
+Copyright (C) 2011-2022 by Will McCutchen and individual contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,8 @@ All command line options are given below::
 
 Outputs::
 
-    usage: dycco [-h] [-o OUTPUT_DIR] source_file [source_file ...]
+
+    usage: dycco [-h] [-o OUTPUT_DIR] [-a] [-e] [-f] source_file [source_file ...]
 
     Literate-style documentation generator.
 

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ Outputs::
       -h, --help            show this help message and exit
       -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                             Output directory (will be created if necessary)
+      -a, --asciidoc3       Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)
+
 
 Library Usage
 -------------

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,13 @@ example and more information, see `its self-generated docs`_.
 
 This port of Docco has fewer features than the pimary Python port, `Pycco`_.
 For instance, Dycco can generate documentation for Python files and nothing
-else. It was written mostly as a reason to play with Python's AST.
+else. It was written mostly as a reason to play with Python's AST. However, this
+version allows output to a markdown file or to an asciidoc3 file, as well
+as adding a option to sanitize internal HTML (which is handy if your code
+included html fragments).
 
-You can use `Pycco`_ instead.
+You can use `Pycco`_ instead, or a newer version (`still in development`_)
+that uses Dycco internally to handle Python files.
 
 
 Installation
@@ -78,9 +82,11 @@ Credits
 =======
 
 Dycco is just a simple re-implementation of `Docco`_, with some inspiration and
-template code from its primary Python port `Pycco`_.
+template code from its primary Python port `Pycco`_ (`and an updated version`_)
 
 .. _Docco: https://ashkenas.com/docco/
 .. _Pycco: https://github.com/pycco-docs/pycco
 .. _pip: http://www.pip-installer.org/
-.. _its self-generated docs: https://mccutchen.github.io/dycco/
+.. _its self-generated docs: https://rojalator.github.io/dycco.html
+.. _still in development : https://github.com/rojalator/pycco
+.. _and an updated version : https://github.com/rojalator/pycco

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Credits
 Dycco is just a simple re-implementation of `Docco`_, with some inspiration and
 template code from its primary Python port `Pycco`_.
 
-.. _Docco: http://jashkenas.github.com/docco/
-.. _Pycco: http://fitzgen.github.com/pycco/
+.. _Docco: https://ashkenas.com/docco/
+.. _Pycco: https://github.com/pycco-docs/pycco
 .. _pip: http://www.pip-installer.org/
 .. _its self-generated docs: https://mccutchen.github.io/dycco/

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ This port of Docco has fewer features than the pimary Python port, `Pycco`_.
 For instance, Dycco can generate documentation for Python files and nothing
 else. It was written mostly as a reason to play with Python's AST.
 
-You should probably use `Pycco`_ instead.
+You can use `Pycco`_ instead.
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ Outputs::
                             Output directory (will be created if necessary)
       -a, --asciidoc3       Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)
       -e, --escape-html     Run the documentation through html.escape() before markdown or asciidoc3
+      -f, --single-file     Just produce a .md or .adoc file in single-column to be processed externally
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ Outputs::
       -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                             Output directory (will be created if necessary)
       -a, --asciidoc3       Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)
+      -e, --escape-html     Run the documentation through html.escape() before markdown or asciidoc3
+
 
 
 Library Usage

--- a/dycco/__init__.py
+++ b/dycco/__init__.py
@@ -1,1 +1,1 @@
-from .dycco import document, parse  # noqa
+from .dycco import document, parse, preprocess_docs  # noqa

--- a/dycco/__init__.py
+++ b/dycco/__init__.py
@@ -1,1 +1,1 @@
-from .dycco import document, parse, preprocess_docs  # noqa
+from .dycco import document, parse, preprocess_docs, preprocess_code  # noqa

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -5,9 +5,9 @@ import sys
 from .dycco import document
 
 
-def main(paths, output_dir, use_ascii:bool):
+def main(paths, output_dir, use_ascii:bool, escape_html:bool):
     try:
-        document(paths, output_dir, use_ascii)
+        document(paths, output_dir, use_ascii, escape_html)
     except IOError as e:
         logging.error('Unable to open file: %s', e)
         return 1
@@ -24,6 +24,8 @@ if __name__ == '__main__':
     arg_parser.add_argument('-o', '--output-dir', default='docs', help='Output directory (will be created if necessary)')
     arg_parser.add_argument('-a', '--asciidoc3', action='store_true', default=False, dest='use_ascii',
         help='Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)')
+    arg_parser.add_argument('-e', '--escape-html', action='store_true', default=False, dest='escape_html',
+        help='Run the documentation through html.escape() before markdown or asciidoc3')
 
     args = arg_parser.parse_args()
-    sys.exit(main(args.source_file, args.output_dir, args.use_ascii))
+    sys.exit(main(args.source_file, args.output_dir, args.use_ascii, args.escape_html))

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -5,9 +5,9 @@ import sys
 from .dycco import document
 
 
-def main(paths, output_dir, use_ascii:bool, escape_html:bool):
+def main(paths, output_dir, use_ascii:bool, escape_html:bool, single_file:bool):
     try:
-        document(paths, output_dir, use_ascii, escape_html)
+        document(paths, output_dir, use_ascii, escape_html, single_file)
     except IOError as e:
         logging.error('Unable to open file: %s', e)
         return 1
@@ -26,6 +26,8 @@ if __name__ == '__main__':
         help='Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)')
     arg_parser.add_argument('-e', '--escape-html', action='store_true', default=False, dest='escape_html',
         help='Run the documentation through html.escape() before markdown or asciidoc3')
+    arg_parser.add_argument('-f', '--single-file', action='store_true', default=False, dest='single_file',
+        help='Just produce a .md or .adoc file in single-column to be processed externally')
 
     args = arg_parser.parse_args()
-    sys.exit(main(args.source_file, args.output_dir, args.use_ascii, args.escape_html))
+    sys.exit(main(args.source_file, args.output_dir, args.use_ascii, args.escape_html, args.single_file))

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -19,15 +19,9 @@ def main(paths, output_dir):
 
 
 if __name__ == '__main__':
-    arg_parser = argparse.ArgumentParser(
-        prog='dycco',
-        description='Literate-style documentation generator.')
-    arg_parser.add_argument(
-        'source_file', nargs='+', default=sys.stdin,
-        help='Source files to document')
-    arg_parser.add_argument(
-        '-o', '--output-dir', default='docs',
-        help='Output directory (will be created if necessary)')
+    arg_parser = argparse.ArgumentParser(prog='dycco', description='Literate-style documentation generator.')
+    arg_parser.add_argument('source_file', nargs='+', default=sys.stdin, help='Source files to document')
+    arg_parser.add_argument('-o', '--output-dir', default='docs', help='Output directory (will be created if necessary)')
 
     args = arg_parser.parse_args()
     sys.exit(main(args.source_file, args.output_dir))

--- a/dycco/__main__.py
+++ b/dycco/__main__.py
@@ -5,9 +5,9 @@ import sys
 from .dycco import document
 
 
-def main(paths, output_dir):
+def main(paths, output_dir, use_ascii:bool):
     try:
-        document(paths, output_dir)
+        document(paths, output_dir, use_ascii)
     except IOError as e:
         logging.error('Unable to open file: %s', e)
         return 1
@@ -22,6 +22,8 @@ if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser(prog='dycco', description='Literate-style documentation generator.')
     arg_parser.add_argument('source_file', nargs='+', default=sys.stdin, help='Source files to document')
     arg_parser.add_argument('-o', '--output-dir', default='docs', help='Output directory (will be created if necessary)')
+    arg_parser.add_argument('-a', '--asciidoc3', action='store_true', default=False, dest='use_ascii',
+        help='Process with asciidoc3 instead of markdown (you will have to install asciidoc3, of course)')
 
     args = arg_parser.parse_args()
-    sys.exit(main(args.source_file, args.output_dir))
+    sys.exit(main(args.source_file, args.output_dir, args.use_ascii))

--- a/dycco/dycco.py
+++ b/dycco/dycco.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """**Dycco** is another Python port of [Docco][docco], the quick-and-dirty,
-hundred-line-long, literate-programming-style documentation generator.
+hundred-line-long, literate-programming-style documentation generator. This
+particular version has been updated to work with Python 3 (as of 2022).
 
 Dycco reads Python source files and produces annotated source documentation in
 HTML format. Comments and docstrings are formatted with [Markdown][markdown] or

--- a/dycco/dycco.py
+++ b/dycco/dycco.py
@@ -56,8 +56,8 @@ DYCCO_CSS = os.path.join(DYCCO_RESOURCES, 'dycco.css')
 # We need a positive integer type
 
 
-# For Python 2 & 3 compatibility, although this code is unlikely
-# to work correctly for Python 2 any more
+# For Python 2 & 3 compatibility (although this code is unlikely
+# to work correctly for Python 2 any more).
 try:
     string_type = basestring
 except NameError:

--- a/dycco/dycco.py
+++ b/dycco/dycco.py
@@ -343,10 +343,14 @@ def preprocess_docs(docs:list, use_ascii:bool, escape_html:bool, raw:bool = Fals
 #### Code - Pygments
 
 
-def preprocess_code(code:list, use_ascii:bool = False, raw:bool = False) -> str:
+def preprocess_code(code:list, use_ascii:bool = False, raw:bool = False, language_name:str = 'python') -> str:
     """Preprocess the given code, which should be a `list` of strings, by
     joining them together and running them through the Pygments syntax
     highlighter unless `raw` is True, when we just return the text
+
+    Although we are strictly python, it's possible that this might get called by other
+    routines as it's quite handy, so allow the language to be specified
+    in `language_name`. Behaviour if `language_name` is blank is undefined (for asciidoc3).
     """
     assert isinstance(code, list)
     # Sometimes code is empty, so just return nothing
@@ -358,10 +362,11 @@ def preprocess_code(code:list, use_ascii:bool = False, raw:bool = False) -> str:
         delimiter = '---------------------------------------------------------------------'
         if use_ascii:
             # ...either asciidoc3's markers...
-            code_block = '\n[source,python]\n{0}\n{1}\n{0}\n'.format(delimiter, '\n'.join(code), delimiter)
+            code_block = '\n[source,{2}]\n{0}\n{1}\n{0}\n'.format(delimiter, '\n'.join(code), language_name)
         else:
-            # ...or Markdown's markers - it has to be indented for markdown hence the `\t`
-            code_block = '{0}\n\t{1}\n{0}\n'.format(delimiter, '\n\t'.join(code), delimiter)
+            # ...or Markdown's markers
+            delimiter = "```"
+            code_block = '{0}{2}\n{1}\n{0}\n'.format(delimiter, '\n'.join(code), language_name)
         return code_block
     else:
         # Do what we always used to - pass througn Pygments

--- a/dycco/tests/input/bad_shebang_and_coding.py
+++ b/dycco/tests/input/bad_shebang_and_coding.py
@@ -1,4 +1,5 @@
 # Shebang must come first
 #!/usr/bin/env/python2.6
+
 # -*- coding: utf8 -*-
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/bad_shebang_and_coding.py
+++ b/dycco/tests/input/bad_shebang_and_coding.py
@@ -1,5 +1,4 @@
 # Shebang must come first
 #!/usr/bin/env/python2.6
-
 # -*- coding: utf8 -*-
 print('Hello, World!')

--- a/dycco/tests/input/skip_coding.py
+++ b/dycco/tests/input/skip_coding.py
@@ -1,2 +1,2 @@
 # coding=utf8
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_emacs_coding.py
+++ b/dycco/tests/input/skip_emacs_coding.py
@@ -1,2 +1,2 @@
 # -*- coding: utf8 -*-
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_shebang.py
+++ b/dycco/tests/input/skip_shebang.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python2.6
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/skip_shebang_and_coding.py
+++ b/dycco/tests/input/skip_shebang_and_coding.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env/python2.6
 # -*- coding: utf8 -*-
-print 'Hello, World!'
+print('Hello, World!')

--- a/dycco/tests/input/torturetest.py
+++ b/dycco/tests/input/torturetest.py
@@ -88,4 +88,4 @@ def decorated_function_definition(function, which, takes, many, args, whose,
     """A *decorated* long function definition With some very important
     documentation.
     """
-    print 'Hello!'
+    print('Hello!')

--- a/dycco/tests/tests.py
+++ b/dycco/tests/tests.py
@@ -60,9 +60,8 @@ class ParserTests(unittest.TestCase):
 
     @with_setup
     def test_torturetest(self):
-        print()
-        for result in self.results.items():
-            print(result)
+        # The output test has been adjusted slightly - the old code
+        # occasionally separated decorators (not always).
         self.maxDiff = None
         self.assertEqual(
             self.results,
@@ -79,9 +78,9 @@ class ParserTests(unittest.TestCase):
                  'Single-line docstring'],
                  'code': ['class Foo(object):', '']},
              37: {'docs': ['### A singly-decorated method'],
-                  'code': ['    @classmethod']},
+                  'code': []},
              38: {'docs': ['A multiline docstring with leading and trailing breaks.\n\nWhat do you think of that?'],
-                  'code': ['    def method1(cls):', '        pass', '']},
+                  'code': ['    @classmethod', '    def method1(cls):', '        pass', '']},
              73: {'docs': ['## Utility functions'],
                   'code': ['']},
              74: {'docs': [None],
@@ -98,7 +97,7 @@ class ParserTests(unittest.TestCase):
                            '            return 42',
                            '',
                            '        return foo', '']},
-             84: {'docs': ['A *decorated* long function definition With some very important\ndocumentation.'],
+             85: {'docs': ['A *decorated* long function definition With some very important\ndocumentation.'],
                   'code': [
                         '@wraps(bar)',
                         'def decorated_function_definition(function, which, takes, many, args, whose,',
@@ -112,7 +111,7 @@ class ParserTests(unittest.TestCase):
                            '']},
              52: {'docs': ['A mutliply-decorated method, with no docstring. How will this look\n to your parents?'],
                   'code': ['']},
-             61: {'docs': ['A mutliply-decorated method, *with* a docstring. Better? I\ncertainly hope so.'],
+             64: {'docs': ['A mutliply-decorated method, *with* a docstring. Better? I\ncertainly hope so.'],
                   'code': ['    @property',
                            '    @wraps(method1)',
                            '    @classmethod',

--- a/dycco/tests/tests.py
+++ b/dycco/tests/tests.py
@@ -1,6 +1,9 @@
 import unittest
 from utils import with_setup
 
+# Adjusted for Python 3 version - v1.0.2 and above, RJL 2022
+# For example, `print` now is `print()`. There are also some changes
+# due to the AST / compiler changes in Python 3
 
 class ParserTests(unittest.TestCase):
 
@@ -8,32 +11,32 @@ class ParserTests(unittest.TestCase):
     def test_skip_shebang(self):
         self.assertEqual(
             self.results,
-            {1: {'docs': [], 'code': ["print 'Hello, World!'"]}})
+            {1: {'docs': [], 'code': ["print('Hello, World!')"]}})
 
     @with_setup
     def test_skip_coding(self):
         self.assertEqual(
             self.results,
-            {1: {'docs': [], 'code': ["print 'Hello, World!'"]}})
+            {1: {'docs': [], 'code': ["print('Hello, World!')"]}})
 
     @with_setup
     def test_skip_emacs_coding(self):
         self.assertEqual(
             self.results,
-            {1: {'docs': [], 'code': ["print 'Hello, World!'"]}})
+            {1: {'docs': [], 'code': ["print('Hello, World!')"]}})
 
     @with_setup
     def test_skip_shebang_and_coding(self):
         self.assertEqual(
             self.results,
-            {2: {'docs': [], 'code': ["print 'Hello, World!'"]}})
+            {2: {'docs': [], 'code': ["print('Hello, World!')"]}})
 
     @with_setup
     def test_bad_shebang_and_coding(self):
         self.assertEqual(
             self.results,
             {3: {'docs': ['Shebang must come first\n!/usr/bin/env/python2.6\n -*- coding: utf8 -*-'],
-                 'code': ["print 'Hello, World!'"]}})
+                 'code': ["print('Hello, World!')"]}})
 
     @with_setup
     def test_module_docstring(self):
@@ -57,15 +60,28 @@ class ParserTests(unittest.TestCase):
 
     @with_setup
     def test_torturetest(self):
+        print()
+        for result in self.results.items():
+            print(result)
+        self.maxDiff = None
         self.assertEqual(
             self.results,
             {3: {'docs': ['## A Module-Level Docstring\n\nLorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo\nligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis\nparturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,\npellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec\npede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo,\nrhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede\nmollis pretium. Integer tincidunt. Cras dapibus.\n\nVivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo\nligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante,\ndapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus\nvarius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel\naugue. Curabitur ullamcorper ultricies nisi.'],
                  'code': []},
-             37: {'docs': ['### A singly-decorated method', 'A multiline docstring with leading and trailing breaks.\n\nWhat do you think of that?'],
-                  'code': [
-                        '    @classmethod',
-                        '    def method1(cls):',
-                        '        pass', '']},
+             22: {'docs': ['Some imports'],
+                  'code': ['import sys, os, re',
+                           'from functools import wraps',
+                           'import itertools',
+                           '',
+                           '']},
+             28: {'docs': [
+                 '## This is an important class',
+                 'Single-line docstring'],
+                 'code': ['class Foo(object):', '']},
+             37: {'docs': ['### A singly-decorated method'],
+                  'code': ['    @classmethod']},
+             38: {'docs': ['A multiline docstring with leading and trailing breaks.\n\nWhat do you think of that?'],
+                  'code': ['    def method1(cls):', '        pass', '']},
              73: {'docs': ['## Utility functions'],
                   'code': ['']},
              74: {'docs': [None],
@@ -87,25 +103,15 @@ class ParserTests(unittest.TestCase):
                         '@wraps(bar)',
                         'def decorated_function_definition(function, which, takes, many, args, whose,',
                         '                                  definition, wraps, across, multiple, lines):',
-                        "    print 'Hello!'"]},
+                        "    print('Hello!')"]},
              78: {'docs': ['A long function definition with some very important documentation.'],
                   'code': ['def really_long_function_definition(function, which, takes, many, args, whose,',
                            '                                    definition, wraps, across, multiple,',
                            '                                    lines):',
                            '    return 2 ** 128',
                            '']},
-             22: {'docs': ['Some imports'],
-                  'code': ['import sys, os, re',
-                           'from functools import wraps',
-                           'import itertools',
-                           '',
-                           '']},
              52: {'docs': ['A mutliply-decorated method, with no docstring. How will this look\n to your parents?'],
                   'code': ['']},
-             28: {'docs': [
-                        '## This is an important class',
-                        'Single-line docstring'],
-                  'code': ['class Foo(object):', '']},
              61: {'docs': ['A mutliply-decorated method, *with* a docstring. Better? I\ncertainly hope so.'],
                   'code': ['    @property',
                            '    @wraps(method1)',

--- a/dycco/tests/utils.py
+++ b/dycco/tests/utils.py
@@ -20,11 +20,15 @@ def with_setup_src(path):
     corresponding source code be given. See `with_setup`, below, for a
     shortcut that uses the test method's name to find the corresponding source
     code.
+
+    RJL: Corrected for v1.0.2 to correctly close the file
     """
     def decorator(method):
         @wraps(method)
         def decorated(self, *args, **kwargs):
-            self.src = open(path).read()
+            the_file = open(path)
+            self.src = the_file.read()
+            the_file.close()
             self.results = dict(dycco.parse(self.src))
             return method(self, *args, **kwargs)
         return decorated

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Markdown==2.4
-Pygments==2.7.4
-pystache==0.5.3
+Markdown>=2.4
+Pygments>=2.7.4
+pystache>=0.5.3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name='dycco',
-    version='1.0.1',
+    version='1.0.2',
     description='Literate-programming-style documentation generator.',
     long_description=read('README.rst'),
     url='https://github.com/mccutchen/dycco',
@@ -23,7 +23,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',


### PR DESCRIPTION
Updated usage in README. Added preprocess_docs() and preprocess_code () to `__init__()` for use by pycco (or whatever). Allowed output to non-html (.adoc or .md) for separate processing. Added ability to escape HTML in documentation as it sometimes disrupts output (if you are writing html-generation code in python, for example and your code mentions, say, <title> the output gets truncated). Added ability to use Asciidoc3 instead of Markdown (or produce .adoc vs .md extension file if --single-file is used).

Previous behaviour has been maintained so exisiting scripts / makefiles using dycco shall be unaffected.

This code should be ready for the next release.